### PR TITLE
Flink fix

### DIFF
--- a/ray_data_eval/image_generation/flink/run.py
+++ b/ray_data_eval/image_generation/flink/run.py
@@ -67,8 +67,8 @@ class Model:
         self.model = AutoPipelineForImage2Image.from_pretrained(
             "stable-diffusion-v1-5/stable-diffusion-v1-5",
             torch_dtype=torch.float16,
-            # variant="fp16",
-            # use_safetensors=True,
+            variant="fp16",
+            use_safetensors=True,
         ).to("cuda")  # StableDiffusionImg2ImgPipeline
 
         self.start_time = time.perf_counter()

--- a/ray_data_eval/image_generation/flink/run.py
+++ b/ray_data_eval/image_generation/flink/run.py
@@ -203,7 +203,7 @@ def run_flink(env):
     start = time.perf_counter()
 
     ds = env.from_collection(
-        IMAGE_PROMPTS_DF.index[500 : 500 + NUM_BATCHES * BATCH_SIZE], type_info=Types.STRING()
+        IMAGE_PROMPTS_DF.index[: NUM_BATCHES * BATCH_SIZE], type_info=Types.STRING()
     )
 
     ds = ds.flat_map(

--- a/ray_data_eval/image_generation/flink/run.py
+++ b/ray_data_eval/image_generation/flink/run.py
@@ -234,8 +234,6 @@ def run_experiment():
     config.set_integer("taskmanager.numberOfTaskSlots", NUM_CPUS)
 
     env = StreamExecutionEnvironment.get_execution_environment(config)
-    # print("checkpoint enabled: ", env.get_checkpoint_config().is_checkpointing_enabled())
-    # print(config.get_integer("taskmanager.numberOfTaskSlots", 0))
 
     run_flink(env)
     postprocess_logs()

--- a/ray_data_eval/image_generation/flink/run.py
+++ b/ray_data_eval/image_generation/flink/run.py
@@ -15,10 +15,6 @@ from pyflink.datastream.functions import (
 import torch
 import numpy as np
 from diffusers import AutoPipelineForImage2Image
-from ray_data_eval.image_generation.raydata.ray_data_pipeline_helpers import (
-    ChromeTracer,
-    # CsvLogger,
-)
 
 
 from ray_data_eval.image_generation.common import (


### PR DESCRIPTION
Prompt texts that are too long could mysteriously error here when passed into the model, although usually they should be handled and clipped by CLIP automatically. Adding this manual slicing gets rid of the errors:
```
self.prompts_batch.append(get_image_prompt(value[1]))
```
